### PR TITLE
Binary download fix

### DIFF
--- a/minicurl.hpp
+++ b/minicurl.hpp
@@ -433,10 +433,12 @@ class minicurl
 			if(file.good())
 			{
 				// combile url and filename to get the full url path
-				auto chunk = get_singleton().fetch(url + filename, "", "", headers).content;
+				auto chunk = get_singleton().fetch(url, "", "", headers).content;
 				if(chunk.size > 1)
 				{
-					file << chunk.data << std::flush;
+					// persist data as is, without the null terminator
+					file.write(chunk.data, chunk.size);
+					file.flush();
 				}
 				file.close();
 				return confirmed_filename;

--- a/test.cpp
+++ b/test.cpp
@@ -27,23 +27,23 @@
 
 int main()
 {
-	std::cerr << "HTTP GET:\n\n" << minicurl::get("http://httpbin.org/get") << "\n\n";
+	std::cout << "HTTP GET:\n\n" << minicurl::get("http://httpbin.org/get") << "\n\n";
 	
-	std::cerr << "HTTP GET with query string:\n\n" << minicurl::get("http://httpbin.org/get?HELLO=WORLD") << "\n\n";
+	std::cout << "HTTP GET with query string:\n\n" << minicurl::get("http://httpbin.org/get?HELLO=WORLD") << "\n\n";
 	
-	std::cerr << "HTTP GET with header information:\n\n" << minicurl::get("http://httpbin.org/get", {"HELLO:WORLD", "GOODBYE:WORLD"}) << "\n\n";
+	std::cout << "HTTP GET with header information:\n\n" << minicurl::get("http://httpbin.org/get", {"HELLO:WORLD", "GOODBYE:WORLD"}) << "\n\n";
 	
-	std::cerr << "HTTP GET with non-valued header information:\n\n" << minicurl::get("http://httpbin.org/get", {"HELLO:", "WORLD;", "GOODBYE"}) << "\n\n";
+	std::cout << "HTTP GET with non-valued header information:\n\n" << minicurl::get("http://httpbin.org/get", {"HELLO:", "WORLD;", "GOODBYE"}) << "\n\n";
 	
-	std::cerr << "HTTP POST with plain text as payload:\n\n" << minicurl::post("http://httpbin.org/post", "HELLO_WORLD") << "\n\n";
+	std::cout << "HTTP POST with plain text as payload:\n\n" << minicurl::post("http://httpbin.org/post", "HELLO_WORLD") << "\n\n";
 	
-	std::cerr << "HTTP POST with stringfied json as payload:\n\n" << minicurl::post("http://httpbin.org/post", "{HELLO:\"WORLD\"}", {"Content-type: application/json"}) << "\n\n";
+	std::cout << "HTTP POST with stringfied json as payload:\n\n" << minicurl::post("http://httpbin.org/post", "{HELLO:\"WORLD\"}", {"Content-type: application/json"}) << "\n\n";
 	
-	std::cerr << "Getting header information:\n\n" << minicurl::get_header("http://httpbin.org/get") << "\n\n";
+	std::cout << "Getting header information:\n\n" << minicurl::get_header("http://httpbin.org/get") << "\n\n";
 	
-	std::cerr << "Uploading a file to an address:\n\n" << minicurl::upload("https://httpbin.org/put", "README.md") << "\n\n";
+	std::cout << "Uploading a file to an address:\n\n" << minicurl::upload("https://httpbin.org/put", "README.md") << "\n\n";
 	
-	std::cerr << "Downloading to an optionally specified file (returns filename if succeeded, empty string if failed):\n\n" << minicurl::download("http://httpbin.org/get", "DOWNLOADED.txt") << "\n\n";
+	std::cout << "Downloading to an optionally specified file (returns filename if succeeded, empty string if failed):\n\n" << minicurl::download("http://httpbin.org/get", "DOWNLOADED.txt") << "\n\n";
 	
 	return 0;
 }


### PR DESCRIPTION
1. Remove null terminator from chunk persistence.  Save stream as is.
2. Save binary file without adding null terminators.
3. Add content-length header required by HTTP/1.1.
4. Added additional logging.
